### PR TITLE
Updated to ECS 5.5 (required for Nette 3)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,14 +3,15 @@
 	"license": "MIT",
 	"require": {
 		"php": "^7.1",
-		"symplify/better-phpdoc-parser": "5.4.13",
-		"symplify/easy-coding-standard": "5.4.13",
-		"symplify/coding-standard": "5.4.13",
-		"slevomat/coding-standard": "^4.8.5"
+		"symplify/easy-coding-standard": "^5.5",
+		"symplify/coding-standard": "^5.5",
+		"slevomat/coding-standard": "^5.0"
 	},
 	"require-dev": {
 		"tracy/tracy": "^2.5"
 	},
+	"prefer-stable": true,
+	"minimum-stability": "dev",
 	"autoload": {
 		"psr-4": {
 			"Nette\\CodingStandard\\": "src"

--- a/ecs
+++ b/ecs
@@ -3,7 +3,7 @@
 
 use Composer\XdebugHandler\XdebugHandler;
 use Symfony\Component\DependencyInjection\Container;
-use Symplify\EasyCodingStandard\Console\EasyCodingStandardApplication;
+use Symplify\EasyCodingStandard\Console\EasyCodingStandardConsoleApplication;
 
 require_once __DIR__ . '/vendor/symplify/easy-coding-standard/bin/autoload.php';
 
@@ -17,5 +17,5 @@ unset($xdebug);
 /** @var Container $container */
 $container = require __DIR__ . '/vendor/symplify/easy-coding-standard/bin/container.php';
 
-$application = $container->get(EasyCodingStandardApplication::class);
+$application = $container->get(EasyCodingStandardConsoleApplication::class);
 exit($application->run());

--- a/src/Utils/ClassWrapper.php
+++ b/src/Utils/ClassWrapper.php
@@ -7,7 +7,7 @@ namespace Nette\CodingStandard\Utils;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 use PhpCsFixer\Tokenizer\TokensAnalyzer;
-use Symplify\TokenRunner\Guard\TokenTypeGuard;
+use Symplify\CodingStandard\TokenRunner\Guard\TokenTypeGuard;
 
 final class ClassWrapper
 {


### PR DESCRIPTION
I am adding this for future reference and testing. 

[symplify/easy-coding-standard](https://github.com/Symplify/EasyCodingStandard) and [symplify/coding-standard](https://github.com/Symplify/CodingStandard) are still in a dev phase. Other than that it seems to be working well with Nette 3 and doing what it should (it finds same errors in our project as v2.1.2). Tests are passing ([see CI](https://travis-ci.org/ikeblaster/coding-standard)), but they don't seem to be really thorough.