### PR TITLE
Updated ECS to 6.0.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,10 +3,9 @@
 	"license": "MIT",
 	"require": {
 		"php": "^7.1",
-		"symplify/better-phpdoc-parser": "5.4.13",
-		"symplify/easy-coding-standard": "5.4.13",
-		"symplify/coding-standard": "5.4.13",
-		"slevomat/coding-standard": "^4.8.5"
+		"symplify/easy-coding-standard": "6.0.2",
+		"symplify/coding-standard": "6.0.2",
+		"slevomat/coding-standard": "^5.0.4"
 	},
 	"require-dev": {
 		"tracy/tracy": "^2.5"

--- a/ecs
+++ b/ecs
@@ -2,20 +2,71 @@
 <?php declare(strict_types=1);
 
 use Composer\XdebugHandler\XdebugHandler;
-use Symfony\Component\DependencyInjection\Container;
-use Symplify\EasyCodingStandard\Console\EasyCodingStandardApplication;
-
-require_once __DIR__ . '/vendor/symplify/easy-coding-standard/bin/autoload.php';
+use Symfony\Component\Console\Input\ArgvInput;
+use Symplify\EasyCodingStandard\Console\EasyCodingStandardConsoleApplication;
+use Symplify\EasyCodingStandard\HttpKernel\EasyCodingStandardKernel;
+use Symplify\PackageBuilder\Configuration\ConfigFileFinder;
+use Symplify\PackageBuilder\Configuration\LevelFileFinder;
+use Symplify\PackageBuilder\Console\Input\InputDetector;
 
 // performance boost
 gc_disable();
 
+# 1. autoload
+require_once __DIR__ . '/vendor/autoload.php';
+require_once __DIR__ . '/vendor/squizlabs/php_codesniffer/autoload.php';
+
+// performance boost
 $xdebug = new XdebugHandler('ecs', '--ansi');
 $xdebug->check();
 unset($xdebug);
 
-/** @var Container $container */
-$container = require __DIR__ . '/vendor/symplify/easy-coding-standard/bin/container.php';
+# 2. create container
 
-$application = $container->get(EasyCodingStandardApplication::class);
+// Detect configuration from level option
+$configs = [];
+$configs[] = (new LevelFileFinder())->detectFromInputAndDirectory(new ArgvInput(), __DIR__ . '/../config/');
+
+// Fallback to config option
+ConfigFileFinder::detectFromInput('ecs', new ArgvInput());
+$configs[] = ConfigFileFinder::provide(
+	'ecs',
+	['easy-coding-standard.yml', 'easy-coding-standard.yaml', 'ecs.yml', 'ecs.yaml']
+);
+
+if (version_compare(PHP_VERSION, '7.0.0', '<=')) {
+    $configs[] = __DIR__ . '/coding-standard-php56.yml';
+} elseif (version_compare(PHP_VERSION, '7.1.0', '<=')) {
+    $configs[] = __DIR__ . '/coding-standard-php70.yml';
+} else {
+    $configs[] = __DIR__ . '/coding-standard-php71.yml';
+}
+
+// remove empty values
+$configs = array_filter($configs);
+
+/**
+ * @param string[] $configs
+ */
+function computeConfigHash(array $configs): string
+{
+	$hash = '';
+	foreach ($configs as $config) {
+		$hash .= md5_file($config);
+	}
+
+	return $hash;
+}
+
+$environment = 'prod' . computeConfigHash($configs) . random_int(1, 100000);
+$easyCodingStandardKernel = new EasyCodingStandardKernel($environment, InputDetector::isDebug());
+if ($configs !== []) {
+	$easyCodingStandardKernel->setConfigs($configs);
+}
+
+$easyCodingStandardKernel->boot();
+$container = $easyCodingStandardKernel->getContainer();
+
+# 3. run
+$application = $container->get(EasyCodingStandardConsoleApplication::class);
 exit($application->run());

--- a/src/Sniffs/WhiteSpace/FunctionSpacingSniff.php
+++ b/src/Sniffs/WhiteSpace/FunctionSpacingSniff.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 /**
  * Checks the separation between methods in a class or interface.
  *

--- a/src/Utils/ClassWrapper.php
+++ b/src/Utils/ClassWrapper.php
@@ -7,7 +7,7 @@ namespace Nette\CodingStandard\Utils;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 use PhpCsFixer\Tokenizer\TokensAnalyzer;
-use Symplify\TokenRunner\Guard\TokenTypeGuard;
+use Symplify\CodingStandard\TokenRunner\Guard\TokenTypeGuard;
 
 final class ClassWrapper
 {


### PR DESCRIPTION
This also deprecates https://github.com/nette/coding-standard/pull/35