### PR TITLE
Updated to ECS 6.0.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,8 +3,8 @@
 	"license": "MIT",
 	"require": {
 		"php": "^7.1",
-		"symplify/easy-coding-standard": "6.0.2",
-		"symplify/coding-standard": "6.0.2",
+		"symplify/easy-coding-standard": "6.0.4",
+		"symplify/coding-standard": "6.0.4",
 		"slevomat/coding-standard": "^5.0.4"
 	},
 	"require-dev": {


### PR DESCRIPTION
Will fix annoying warning during run:
```
PHP Deprecated:
"Symplify\PackageBuilder\DependencyInjection\CompilerPass\AutowireSinglyImplementedCompilerPass"
is deprecated due to unpredictable behavior and causing too many bugs.
Use explicit interface autowiring, see https://symfony.com/doc/current/service_container/autowiring.html#working-with-interfaces
in /home/liquid/projects/forks/nette/coding-standard/vendor/symplify/package-builder/src/DependencyInjection/CompilerPass/AutowireSinglyImplementedCompilerPass.php on line 39
```