### PR TITLE
Add rule file for PHP 8.0

### DIFF
--- a/preset/php80.php
+++ b/preset/php80.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+return function (Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator $containerConfigurator): void {
+	$containerConfigurator->import(__DIR__ . '/php74.php');
+
+	$services = $containerConfigurator->services();
+
+	// Reserved for future use
+};


### PR DESCRIPTION
I can not convert my package to PHP 8, because the rule file does not exist.

I think it can be defined with inherence to PHP 7.4.

![Snímek obrazovky 2021-01-02 v 10 41 10](https://user-images.githubusercontent.com/4738758/103454716-0893ea80-4ce7-11eb-94bf-2be336a3e892.png)

Thanks.