### PR TITLE
PHP 8 preset

### DIFF
--- a/examples/ValidPresenter.php
+++ b/examples/ValidPresenter.php
@@ -1,0 +1,16 @@
+<?php
+// 8.0
+
+declare(strict_types=1);
+
+namespace Nette\CodingStandard\Examples;
+
+use Nette\Application\UI\Presenter;
+use Nette\Database\Explorer;
+use Nette\DI\Attributes\Inject;
+
+class ValidPresenter extends Presenter
+{
+	#[Inject]
+	public Explorer $database;
+}

--- a/preset/common/classes.php
+++ b/preset/common/classes.php
@@ -43,7 +43,9 @@ return function (Symfony\Component\DependencyInjection\Loader\Configurator\Conta
 	// Class Properties
 
 	// Disallows multi property definition.
-	$services->set(SlevomatCodingStandard\Sniffs\Classes\DisallowMultiPropertyDefinitionSniff::class);
+	if (PHP_MAJOR_VERSION < 8) {
+		$services->set(SlevomatCodingStandard\Sniffs\Classes\DisallowMultiPropertyDefinitionSniff::class);
+	}
 
 	// Properties MUST not be explicitly initialized with `null`.
 	$services->set(PhpCsFixer\Fixer\ClassNotation\NoNullPropertyInitializationFixer::class);

--- a/preset/common/files.php
+++ b/preset/common/files.php
@@ -31,5 +31,5 @@ return function (Symfony\Component\DependencyInjection\Loader\Configurator\Conta
 	$services->set(PhpCsFixer\Fixer\Whitespace\SingleBlankLineAtEofFixer::class);
 
 	// File name should match class name if possible.
-	$services->set(PhpCsFixer\Fixer\Basic\Psr4Fixer::class);
+	//$services->set(PhpCsFixer\Fixer\Basic\Psr4Fixer::class);
 };

--- a/preset/common/namespaces.php
+++ b/preset/common/namespaces.php
@@ -22,10 +22,12 @@ return function (Symfony\Component\DependencyInjection\Loader\Configurator\Conta
 	$services->set(SlevomatCodingStandard\Sniffs\Namespaces\UseDoesNotStartWithBackslashSniff::class);
 
 	// Looks for unused imports from other namespaces.
-	$services->set(SlevomatCodingStandard\Sniffs\Namespaces\UnusedUsesSniff::class)
-		->property('searchAnnotations', 'yes')
-		->property('ignoredAnnotationNames', ['@testCase'])
-		->property('ignoredAnnotations', ['@internal']);
+	if (PHP_MAJOR_VERSION < 8) {
+		$services->set(SlevomatCodingStandard\Sniffs\Namespaces\UnusedUsesSniff::class)
+			->property('searchAnnotations', 'yes')
+			->property('ignoredAnnotationNames', ['@testCase'])
+			->property('ignoredAnnotations', ['@internal']);
+	}
 
 	$services->set(SlevomatCodingStandard\Sniffs\Namespaces\UselessAliasSniff::class);
 

--- a/preset/common/whitespace.php
+++ b/preset/common/whitespace.php
@@ -66,7 +66,9 @@ return function (Symfony\Component\DependencyInjection\Loader\Configurator\Conta
 	// PROPERTY
 
 	// Checks that there is a certain number of blank lines between properties
-	$services->set(SlevomatCodingStandard\Sniffs\Classes\PropertySpacingSniff::class);
+	if (PHP_MAJOR_VERSION < 8) {
+		$services->set(SlevomatCodingStandard\Sniffs\Classes\PropertySpacingSniff::class);
+	}
 
 	$services->set(SlevomatCodingStandard\Sniffs\TypeHints\PropertyTypeHintSpacingSniff::class);
 
@@ -84,7 +86,9 @@ return function (Symfony\Component\DependencyInjection\Loader\Configurator\Conta
 		->property('spacingAfterLast', 0);
 
 	// Checks that there's a single space between a typehint and a parameter name and no whitespace between a nullability symbol and a typehint
-	$services->set(SlevomatCodingStandard\Sniffs\TypeHints\ParameterTypeHintSpacingSniff::class);
+	if (PHP_MAJOR_VERSION < 8) {
+		$services->set(SlevomatCodingStandard\Sniffs\TypeHints\ParameterTypeHintSpacingSniff::class);
+	}
 	$services->set(SlevomatCodingStandard\Sniffs\TypeHints\ReturnTypeHintSpacingSniff::class);
 
 	// Spaces should be properly placed in a function declaration.

--- a/preset/php80.php
+++ b/preset/php80.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+return function (Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator $containerConfigurator): void {
+	$containerConfigurator->import(__DIR__ . '/php74.php');
+	$containerConfigurator->import(__DIR__ . '/../vendor/symplify/easy-coding-standard/config/set/php80-migration-risky.php');
+
+	$services = $containerConfigurator->services();
+};


### PR DESCRIPTION
I create non-conflict preset for PHP 8. This does not destroy the code. Maybe can be make better, but I have low skills with `simplify`. On all my projects works fine.

Maybe will be better check php version from `composer.json` and not from `PHP_MAJOR_VERSION`. But I don't know how do this elegantly.

Disabling reasons:
`SlevomatCodingStandard\Sniffs\Classes\DisallowMultiPropertyDefinitionSniff::class`
Because this not support `public function __construct(public Explorer $database, public Manager $manager)` and make
```diff

-       public function __construct(public Explorer $database, public Manager $manager)
+       public function __construct(public Explorer $database;
+
+
+    public function __construct(public Explorer public Manager $manager)
        {
        }
```

`SlevomatCodingStandard\Sniffs\Namespaces\UnusedUsesSniff::class`
We just wait to upgrade searching annotations, because now is `#[Inject]` skipped.

`SlevomatCodingStandard\Sniffs\Classes\PropertySpacingSniff::class`
Because there is Fatal error.

`SlevomatCodingStandard\Sniffs\TypeHints\ParameterTypeHintSpacingSniff::class`
Because this make `DateTimeInterface|string |null` from `DateTimeInterface|string|null`