### PR TITLE
Update base.php

### DIFF
--- a/preset-fixer/base.php
+++ b/preset-fixer/base.php
@@ -3,7 +3,9 @@
 declare(strict_types=1);
 
 $files = file(__DIR__ . '/../filelist.tmp', FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
-$files = array_map(fn($path) => new SplFileInfo($path), $files);
+$files = array_map(function ($path) {
+	return new SplFileInfo($path);
+}, $files);
 
 $config = new PhpCsFixer\Config;
 $config->registerCustomFixers([


### PR DESCRIPTION
Fix: Parse error: syntax error, unexpected '=>' (T_DOUBLE_ARROW), expecting ',' or ')' in /coding-standard/preset-fixer/base.php on line 6

PHP 7.2



