### PR TITLE
Added options for output format

### DIFF
--- a/fix.php
+++ b/fix.php
@@ -28,6 +28,8 @@ set_time_limit(0);
 
 // parse arguments
 $paths = [];
+$finderFormat = 'txt';
+$snifferFormat = 'source';
 $preset = null;
 $dry = true;
 
@@ -39,7 +41,11 @@ for ($i = 1; $i < count($argv); $i++) {
 		$dry = false;
 	} elseif ($arg === 'check') {
 		// ignore
-	} else {
+	} elseif ($arg === '--finder-output-format') {
+		$finderFormat = $argv[++$i];
+	} elseif ($arg === '--sniffer-output-format') {
+		$snifferFormat = $argv[++$i];
+	}else {
 		$paths[] = $arg;
 	}
 }
@@ -85,7 +91,7 @@ $finder = PhpCsFixer\Finder::create()
 			|| version_compare(PHP_VERSION, $m[1], '>=');
 	})
 	->in($paths);
-
+	
 $fileList = __DIR__ . '/filelist.tmp';
 file_put_contents($fileList, implode("\n", iterator_to_array($finder)));
 
@@ -95,6 +101,7 @@ passthru(
 	PHP_BINARY . ' ' . escapeshellarg($vendorDir . '/friendsofphp/php-cs-fixer/php-cs-fixer')
 	. ' fix -v'
 	. ($dry ? ' --dry-run' : '')
+	. ' --format ' . $finderFormat
 	. ' --config ' . escapeshellarg(__DIR__ . "/preset-fixer/$preset.php"),
 	$code
 );
@@ -119,6 +126,7 @@ passthru(
 	. ' --extensions=php,phpt'
 	. ' --runtime-set ignore_warnings_on_exit true'
 	. ' --no-cache'
+	. ' --report=' . $snifferFormat
 	. ' --standard=' . escapeshellarg($presetFile)
 	. ' --file-list=' . escapeshellarg($fileList),
 	$code


### PR DESCRIPTION
Two new command-line parameters: --fixer-output-format and --sniffer-output-format. Both can be used to set up the desired output format from the current format.

- new feature
- BC break? no
- doc PR: nette/docs#???  <!-- highly welcome, see https://nette.org/en/writing -->

<!--
Please use the latest released version (ie. last tagged commit) as a base for PR.

Describe your changes here to communicate to the maintainers why we should accept this pull request.

Please add new tests to show the fix or feature works. And take a moment to read the contributing guide https://nette.org/en/contributing

Thanks for contributing to Nette!
-->
