### PR TITLE
Fix "Method ReflectionProperty::setAccessible() is deprecated since 8.5, as it has no effect"

### DIFF
--- a/src/Fixer/ClassAndTraitVisibilityRequiredFixer.php
+++ b/src/Fixer/ClassAndTraitVisibilityRequiredFixer.php
@@ -65,7 +65,9 @@ final class ClassAndTraitVisibilityRequiredFixer extends AbstractFixer implement
 		 * and "applyFix()" is final, there is no other way round it.
 		 */
 		$method = new ReflectionMethod($this->visibilityRequiredFixer, 'applyFix');
-		$method->setAccessible(true);
+		if (version_compare(PHP_VERSION, '8.1.0', '<')) {
+			$method->setAccessible(true);
+		}
 		$method->invoke($this->visibilityRequiredFixer, $file, $tokens);
 	}
 


### PR DESCRIPTION
`setAccessible` is a no-op since 8.1 - see https://wiki.php.net/rfc/make-reflection-setaccessible-no-op
